### PR TITLE
Fixed Banner Link Text Cropped On Mobile Devices #7

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -905,7 +905,6 @@ h6 {
       color: $green;
       padding: 1px;
       text-decoration: none;
-      white-space: nowrap;
 
       &:hover {
         background-color: $red-hover;


### PR DESCRIPTION
**Description of PR**

Removed redundant css causing Banner link text to automatically cropped in smaller devices (portrait mode)

<img width="2041" alt="Screenshot 2022-03-30 at 9 33 05 PM" src="https://user-images.githubusercontent.com/25281055/160885043-d2fdea1c-6020-49ee-ba08-7a34de2d0d6c.png">


**Relevant Issues**  
Fixes #7 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots After Fix**

<img width="2053" alt="Screenshot 2022-03-30 at 10 01 50 PM" src="https://user-images.githubusercontent.com/25281055/160885664-691a0ee3-91fe-4d02-98ef-15eeb0bc7bed.png">

